### PR TITLE
Make sure event isn't null to avoid nil object errors

### DIFF
--- a/lib/logstash/codecs/cloudtrail.rb
+++ b/lib/logstash/codecs/cloudtrail.rb
@@ -20,17 +20,18 @@ class LogStash::Codecs::CloudTrail < LogStash::Codecs::Base
     decoded = LogStash::Json.load(@converter.convert(data))
     decoded['Records'].each do |event|
       event['@timestamp'] = event.delete('eventTime')
-
-      if event.has_key?("requestParameters")
-        if event['requestParameters'].has_key?("disableApiTermination")
-          if event['requestParameters']['disableApiTermination'].class != Hash
-            disableApiTermination = event['requestParameters'].delete('disableApiTermination')
-            event['requestParameters']['disableApiTermination']= {"value" => disableApiTermination}
+      if @event
+        if event.has_key?("requestParameters")
+          if event['requestParameters'].has_key?("disableApiTermination")
+            if event['requestParameters']['disableApiTermination'].class != Hash
+              disableApiTermination = event['requestParameters'].delete('disableApiTermination')
+              event['requestParameters']['disableApiTermination']= {"value" => disableApiTermination}
+            end
           end
         end
-      end
 
-      yield LogStash::Event.new(event)
+        yield LogStash::Event.new(event)
+      end
     end
   end # def decode
 


### PR DESCRIPTION
As seen on issue #15 , seems like the codec receives nil objects that cause the errors.
While this is the easy fix, it might be better to understand why we're getting nil events.