### PR TITLE
Handle 'sourceIpAddress' fields with non-ip address content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.5
+  - [#22](https://github.com/logstash-plugins/logstash-codec-cloudtrail/pull/22)Handle 'sourceIpAddress' fields with non-ip address content by moving them to 'sourceHost' field
+
 ## 3.0.4
   - Don't crash when data doesn't contain some particular elements
 

--- a/lib/logstash/codecs/cloudtrail.rb
+++ b/lib/logstash/codecs/cloudtrail.rb
@@ -38,7 +38,8 @@ class LogStash::Codecs::CloudTrail < LogStash::Codecs::Base
   # API calls from support will fill the sourceIpAddress with a hostname string instead of an ip
   # address.
   def substitute_invalid_ip_address(event)
-    if event["sourceIpAddress"] && event["sourceIpAddress"] !~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
+    source_ip_address = event["sourceIpAddress"]
+    if source_ip_address && source_ip_address !~ Resolv::IPv4::Regex && source_ip_address !~ Resolv::IPv6::Regex
       event["sourceHost"] = event.delete("sourceIpAddress")
     end
   end

--- a/lib/logstash/codecs/cloudtrail.rb
+++ b/lib/logstash/codecs/cloudtrail.rb
@@ -28,8 +28,19 @@ class LogStash::Codecs::CloudTrail < LogStash::Codecs::Base
         end
       end
 
+      substitute_invalid_ip_address(event)
+
       yield LogStash::Event.new(event)
     end
   end # def decode
+
+  # Workaround for https://github.com/logstash-plugins/logstash-codec-cloudtrail/issues/20
+  # API calls from support will fill the sourceIpAddress with a hostname string instead of an ip
+  # address.
+  def substitute_invalid_ip_address(event)
+    if event["sourceIpAddress"] && event["sourceIpAddress"] !~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
+      event["sourceHost"] = event.delete("sourceIpAddress")
+    end
+  end
 
 end # class LogStash::Codecs::CloudTrail

--- a/logstash-codec-cloudtrail.gemspec
+++ b/logstash-codec-cloudtrail.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-cloudtrail'
-  s.version         = '3.0.4'
+  s.version         = '3.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Process AWS CloudTrail formatted messages"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/cloudtrail_spec.rb
+++ b/spec/codecs/cloudtrail_spec.rb
@@ -1,8 +1,20 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/plugin"
 require "logstash/codecs/cloudtrail"
+require 'resolv'
 
 describe LogStash::Codecs::CloudTrail do
+
+  shared_examples_for "it handles valid ip addresses" do
+    it 'should pass through valid ip addresses' do
+      ip_addresses.each do |valid_ip_address|
+        subject.decode("{\"Records\":[{\"sourceIpAddress\":\"#{valid_ip_address}\"}]}") do |event|
+          expect(event.get("sourceIpAddress")).to eq(valid_ip_address)
+          expect(event.get("sourceHost")).to be_nil
+        end
+      end
+    end
+  end
 
   describe '#decode' do
     it 'accepts data without a Records property' do
@@ -17,11 +29,14 @@ describe LogStash::Codecs::CloudTrail do
       }.to yield_control
     end
 
-    it 'accepts records with a valid sourceIpAddress' do
-      subject.decode('{"Records":[{"sourceIpAddress":"111.22.3.3"}]}') do |event|
-       expect(event.get("sourceIpAddress")).to eq("111.22.3.3")
-       expect(event.get("sourceHost")).to be_nil
-      end
+    context 'with ipv4 sourceIpAddress values' do
+      let(:ip_addresses) { ["127.0.0.1", "8.8.8.8", "10.10.10.10", "100.100.100.100", "1.12.123.234"] }
+      it_behaves_like 'it handles valid ip addresses'
+    end
+
+    context 'with ipv6 sourceIpAddress values' do
+      let(:ip_addresses) { ["2001:0db8:85a3:0000:0000:8a2e:0370:7334", "2001:db8:85a3::8a2e:370:7334", "::1", "::"] }
+      it_behaves_like 'it handles valid ip addresses'
     end
 
     it 'accepts records with an invalid sourceIpAddress' do

--- a/spec/codecs/cloudtrail_spec.rb
+++ b/spec/codecs/cloudtrail_spec.rb
@@ -16,5 +16,26 @@ describe LogStash::Codecs::CloudTrail do
         subject.decode('{"Records":[{"requestParameters":null}]}', &b)
       }.to yield_control
     end
+
+    it 'accepts records with a valid sourceIpAddress' do
+      subject.decode('{"Records":[{"sourceIpAddress":"111.22.3.3"}]}') do |event|
+       expect(event.get("sourceIpAddress")).to eq("111.22.3.3")
+       expect(event.get("sourceHost")).to be_nil
+      end
+    end
+
+    it 'accepts records with an invalid sourceIpAddress' do
+      subject.decode('{"Records":[{"sourceIpAddress":"www.elastic.co"}]}') do |event|
+        expect(event.get("sourceIpAddress")).to be_nil
+        expect(event.get("sourceHost")).to eq("www.elastic.co")
+      end
+    end
+
+    it 'accepts records with a no sourceIpAddress' do
+      subject.decode('{"Records":[{"sourceIpAddress":null}]}') do |event|
+        expect(event.get("sourceIpAddress")).to be_nil
+        expect(event.get("sourceHost")).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
API calls run from AWS support will appear in AWS logs with
a hostname value, rather than an IP address along the lines of
"support.amazonaws.com". This commit addresses this issue by
moving such fields to a separate 'sourceHost' field in the
event

Fixes #20

